### PR TITLE
fix(logic): Prevent adding '00' when display is '0'

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,6 +40,18 @@ allButtons.addEventListener('click', (event) => {
 });
 
 const handleNumber = (digit) => {
+  if (digit === '00') {
+    if (calculator.displayValue === '0') {
+      return;
+    } else if (calculator.displayValue !== '0' && calculator.waitingForSecondOperand === true) {
+      return;
+    } else {
+      if (calculator.displayValue.length <= 14) {
+        calculator.displayValue += digit;
+      }
+    }
+  }
+
   if (calculator.waitingForSecondOperand) {
     calculator.displayValue = digit;
     calculator.waitingForSecondOperand = false;
@@ -63,6 +75,10 @@ const handleNumber = (digit) => {
     calculator.displayValue = digit;
   } else {
     calculator.displayValue += digit;
+  }
+
+  if (digit === '00' && calculator.displayValue === '0') {
+
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

## What does this implement/fix? Explain your changes.
Creates "guard clause" for the '00' button.
…

## Does this close any currently open issues?
Resolves #29
…

## Any relevant logs, error output, etc?

<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

## Any other comments?

…
